### PR TITLE
Do not force push to gh-pages in automated deploy

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -14,6 +14,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: birchmd/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hopefully this will address https://github.com/aurora-is-near/doc.aurora.dev/pull/8#issuecomment-842520851

I forked the GitHub action and [removed the `--force` option](https://github.com/birchmd/mkdocs-deploy-gh-pages/commit/39fd306ddfa8bc203271b05805ef7dfbb08b34e9) from the script it uses. Again, I'm not sure how to test this other than to merge it and try it out.