### PR TITLE
Standardize network names to use lowercase n

### DIFF
--- a/content/develop/changelog.md
+++ b/content/develop/changelog.md
@@ -79,4 +79,4 @@ title: "Aurora: Changelog"
 ### All networks
 
 - **Aurora Engine**: Deployed release [1.0.0](https://github.com/aurora-is-near/aurora-engine/releases/tag/1.0.0)
-  to MainNet, TestNet, and BetaNet.
+  to Mainnet, Testnet, and Betanet.

--- a/content/develop/compat/gas.md
+++ b/content/develop/compat/gas.md
@@ -29,7 +29,8 @@ In this case the transaction will be considered as failed on Aurora, but this ma
 (if the gas limit was actually high enough for the transaction to complete had NEAR gas not been the limiting factor).
 
 This case will not come up for the vast majority of transactions, and indeed will become less and less likely as we improve the efficiency of our EVM contract
-(thus allowing NEAR gas to go further in terms of EVM computation). Eventually we hope to eliminate this entirely by setting the [ETH block gas limit] on Aurora to be lower than the amount of NEAR which we could spend in one transaction.
+(thus allowing NEAR gas to go further in terms of EVM computation).
+Eventually we hope to eliminate this entirely by setting the [ETH block gas limit] on Aurora to be lower than the amount of NEAR which we could spend in one transaction.
 
 [NEAR gas]: https://docs.near.org/docs/concepts/gas
 [ETH block gas limit]: https://ethereum.org/en/developers/docs/blocks/#block-size

--- a/content/develop/networks.md
+++ b/content/develop/networks.md
@@ -11,10 +11,10 @@ following networks:
 
 Network  | Engine ID                  | Chain ID                | Endpoint URL
 -------- | -------------------------- | ----------------------- | ------------
-[MainNet](#mainnet) | [`aurora`][aurora@MainNet] | 1313161554 (0x4e454152) | <https://mainnet.aurora.dev>
-[TestNet](#testnet) | [`aurora`][aurora@TestNet] | 1313161555 (0x4e454153) | <https://testnet.aurora.dev>
-[BetaNet](#betanet) | [`aurora`][aurora@BetaNet] | 1313161556 (0x4e454154) | <https://betanet.aurora.dev>
-LocalNet | `aurora.test.near`         | 1313161556 (0x4e454154) | <http://localhost:8545>
+[Mainnet](#mainnet) | [`aurora`][aurora@Mainnet] | 1313161554 (0x4e454152) | <https://mainnet.aurora.dev>
+[Testnet](#testnet) | [`aurora`][aurora@Testnet] | 1313161555 (0x4e454153) | <https://testnet.aurora.dev>
+[Betanet](#betanet) | [`aurora`][aurora@Betanet] | 1313161556 (0x4e454154) | <https://betanet.aurora.dev>
+Localnet | `aurora.test.near`         | 1313161556 (0x4e454154) | <http://localhost:8545>
 
 Find the status page and public incident log at
 [api.aurora.dev](https://api.aurora.dev).
@@ -22,21 +22,21 @@ You can also subscribe to incident notifications there.
 
 ## Endpoints
 
-### MainNet
+### Mainnet
 
-The MainNet Web3 endpoint is at: `https://mainnet.aurora.dev` (port 443)
+The Mainnet Web3 endpoint is at: `https://mainnet.aurora.dev` (port 443)
 
-### TestNet
+### Testnet
 
-The TestNet Web3 endpoint is at: `https://testnet.aurora.dev` (port 443)
+The Testnet Web3 endpoint is at: `https://testnet.aurora.dev` (port 443)
 
-### BetaNet
+### Betanet
 
-The BetaNet Web3 endpoint is at: `https://betanet.aurora.dev` (port 443)
+The Betanet Web3 endpoint is at: `https://betanet.aurora.dev` (port 443)
 
-[aurora@MainNet]: https://explorer.near.org/accounts/aurora
-[aurora@TestNet]: https://explorer.testnet.near.org/accounts/aurora
-[aurora@BetaNet]: https://explorer.betanet.near.org/accounts/aurora
+[aurora@Mainnet]: https://explorer.near.org/accounts/aurora
+[aurora@Testnet]: https://explorer.testnet.near.org/accounts/aurora
+[aurora@Betanet]: https://explorer.betanet.near.org/accounts/aurora
 
 [mainnet.aurora.dev]: https://mainnet.aurora.dev
 [testnet.aurora.dev]: https://testnet.aurora.dev

--- a/content/develop/roadmap.md
+++ b/content/develop/roadmap.md
@@ -6,7 +6,7 @@ title: "Aurora: Roadmap"
 
 For the latest roadmap updates, see our posts in the [Aurora forum][1] or the [roadmap section on Aurora website][2].
 
-- **Done** — Deploy Aurora Engine to MainNet, TestNet and BetaNet
+- **Done** — Deploy Aurora Engine to Mainnet, Testnet and Betanet
 - **May 2021** — Transfer ETH and ERC20 tokens beween Ethereum and Aurora
 - **May 2021** — Transfer the NEAR token between Ethereum and NEAR
 - **June 2021** — Completion of Aurora fund-raising campaign

--- a/content/develop/start/metamask.md
+++ b/content/develop/start/metamask.md
@@ -10,7 +10,7 @@ title: "Aurora: Getting Started with MetaMask"
 For the purpose of this guide, we will assume you are already familiar with MetaMask and have it installed.
 If you need help getting started with MetaMask itself, [check out their documentation](https://metamask.io/faqs.html).
 
-In this tutorial we will walk through connecting MetaMask to the Aurora TestNet, deploying a simple ERC-20 contract using [Remix], and transferring the new token using MetaMask.
+In this tutorial we will walk through connecting MetaMask to the Aurora Testnet, deploying a simple ERC-20 contract using [Remix], and transferring the new token using MetaMask.
 
 !!! note
     Screenshots in this tutorial are taken from the MetaMask browser extension version 9.5.5.
@@ -23,7 +23,7 @@ In the top-right corner of the MetaMask interface, click the network selection d
 
 Fill in the form with the following information:
 
-* Network Name: Aurora TestNet
+* Network Name: Aurora Testnet
 * New RPC URL: `https://testnet.aurora.dev/`
 * Chain ID: 1313161555
 * Currency Symbol: ETH
@@ -33,7 +33,7 @@ Fill in the form with the following information:
 !!! note
     All the Aurora RPC endpoint URLs and chain IDs can be found on our [Networks](../networks.md) page.
 
-Click `Save`, and you should see `Aurora TestNet` is now the network selected in MetaMask.
+Click `Save`, and you should see `Aurora Testnet` is now the network selected in MetaMask.
 To see MetaMask in action, we will connect it to [Remix] and perform some transactions.
 
 ## Deploying an ERC-20 Token using Remix
@@ -104,7 +104,7 @@ Now that the contract is deployed on the Aurora network, we can interact with it
 
 ## Adding an ERC-20 Token to MetaMask
 
-In the MetaMask interface (with the Aurora TestNet network still selected), click the `Add Token` button:
+In the MetaMask interface (with the Aurora Testnet network still selected), click the `Add Token` button:
 
 ![MetaMask-add-token-button](../../_img/metamask_add_token_button.png)
 
@@ -150,7 +150,7 @@ If you transferred to another MetaMask account you hold then you can follow the 
 
 ## Summary
 
-In this tutorial we connected MetaMask to the Aurora TestNet, deployed an ERC-20 token contract using Remix, and transferred that token using MetaMask.
+In this tutorial we connected MetaMask to the Aurora Testnet, deployed an ERC-20 token contract using Remix, and transferred that token using MetaMask.
 The only difference to doing this on the original Ethereum network was setting the RPC endpoint to be Aurora's.
 
 [MetaMask]: https://metamask.io

--- a/content/develop/start/truffle.md
+++ b/content/develop/start/truffle.md
@@ -8,7 +8,7 @@ title: "Aurora: Deploying a Contract Using Truffle"
 
 [Truffle](https://www.trufflesuite.com/) is a widely used development
 environment and testing framework for Ethereum smart contracts. In this
-tutorial, we will show by example how to use Truffle with the Aurora TestNet.
+tutorial, we will show by example how to use Truffle with the Aurora Testnet.
 
 This tutorial assumes that you are familiar with Truffle and the non-fungible
 tokens (NFT) concept. For more details about the non-fungible token standard,
@@ -22,7 +22,7 @@ This example is originally forked from the [OpenZeppelin
 examples](https://docs.openzeppelin.com/contracts/4.x/erc721). However, the code
 has been changed to fit the use case of this tutorial. The use case is about how
 to deploy and manage the life cycle of a simple COVID-19 vaccine NFT token 💊💊
-using Truffle on the Aurora TestNet.
+using Truffle on the Aurora Testnet.
 
 ![Truffle NFT example](../../_img/truffle_nft_example.png)
 
@@ -220,5 +220,5 @@ true
 
 ## Summary
 
-In this simple tutorial, we deployed an NFT contract to the Aurora TestNet using
+In this simple tutorial, we deployed an NFT contract to the Aurora Testnet using
 Truffle and interacted with the contract's functions.


### PR DESCRIPTION
Per the meeting earlier, we are standardizing on `Mainnet` `Testnet` and `Betanet`.