### PR TITLE
Additional linter checks: Capitalization style and spelling

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -21,6 +21,11 @@ MD033: false  # no-inline-html
 MD044:        # proper-names
   names:
     - JavaScript
+    - Hardhat
+    - MetaMask
+    - Testnet
+    - Mainnet
+    - Betanet
   code_blocks: false
 MD046: false  # code-block-style
 MD048:        # code-fence-style

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -21,3 +21,7 @@ jobs:
           VALIDATE_MARKDOWN: true
           VALIDATE_YAML: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Spell check
+        uses: crate-ci/typos@master
+        with:
+          files: content/

--- a/content/develop/faq.md
+++ b/content/develop/faq.md
@@ -17,7 +17,7 @@ building upon a technical foundation that will scale to meet all your future nee
 Aurora is a major use case for the NEAR blockchain that requires many changes on different levels.
 At the moment we’re waiting for NEAR validators to accept the protocol change that will add EVM precompiles.
 We expect this to happen in the first half of the summer.
-After this protocol upgrade one can expect Aurora to be able to host twice the throughput of the Ethereum mainnet.
+After this protocol upgrade one can expect Aurora to be able to host twice the throughput of the Ethereum Mainnet.
 There’s still a lot of room for a single-shard Aurora improvement, so we expect further throughput increases.
 
 ## How will transaction fees work?

--- a/content/develop/roadmap.md
+++ b/content/develop/roadmap.md
@@ -7,7 +7,7 @@ title: "Aurora: Roadmap"
 For the latest roadmap updates, see our posts in the [Aurora forum][1] or the [roadmap section on Aurora website][2].
 
 - **Done** — Deploy Aurora Engine to Mainnet, Testnet and Betanet
-- **May 2021** — Transfer ETH and ERC20 tokens beween Ethereum and Aurora
+- **May 2021** — Transfer ETH and ERC-20 tokens between Ethereum and Aurora
 - **May 2021** — Transfer the NEAR token between Ethereum and NEAR
 - **June 2021** — Completion of Aurora fund-raising campaign
 - **June 2021** — Filling of all AuroraDAO initial seats

--- a/content/develop/start/hardhat.md
+++ b/content/develop/start/hardhat.md
@@ -98,7 +98,7 @@ in Hardhat. We will use it for the following commands as well.
 
 The following task script gets the total supply of the Watermelon ERC-20 token.
 First it attachs the
-token contract, gets the sender address and finaly retrieves the total supply
+token contract, gets the sender address and finally retrieves the total supply
 by calling `totalSupply()` method in our ERC-20 contract. The `--token`
 address is the ERC-20 contract address.
 

--- a/content/develop/start/metamask.md
+++ b/content/develop/start/metamask.md
@@ -92,7 +92,7 @@ Click `Confirm`.
 !!! note
     You may be surprised to see the gas price set to zero in this transaction.
     During the early access period Aurora transactions are free, however this will change in the future.
-    Not to worry, even when transaction fees will be non-zero, they'll still be much lower than on the Ethereum 1.0 mainnet.
+    Not to worry, even when transaction fees will be non-zero, they'll still be much lower than on the Ethereum 1.0 Mainnet.
 
 After a few moments the transaction will be confirmed by the network.
 You will see a success message in the bottom panel and the contract listed under `Deployed Contracts` on the left panel.

--- a/content/develop/start/truffle.md
+++ b/content/develop/start/truffle.md
@@ -200,7 +200,7 @@ true
 ### Burn tokens
 
 This is an alternative scenario for the NFT token lifecycle. Instead of
-transfering the token back to the minter, the participant can decide to burn the
+transferring the token back to the minter, the participant can decide to burn the
 NFT token by calling the `burn` function:
 
 ```bash

--- a/content/learn/bridge/eth.md
+++ b/content/learn/bridge/eth.md
@@ -5,11 +5,11 @@ title: "Aurora: Bridging ETH Balances"
 # Bridging ETH Balances
 
 !!! note
-    Bridging ETH is currently only enabled for Ropsten testnet to Aurora testnet.
+    Bridging ETH is currently only enabled for Ropsten Testnet to Aurora Testnet.
 
-Before you begin, ensure you have the Ropsten testnet selected in MetaMask (see instructions [here](../connect/metamask.md)).
+Before you begin, ensure you have the Ropsten Testnet selected in MetaMask (see instructions [here](../connect/metamask.md)).
 
-If you need Ropsten Eth to transfer, you can get some from faucets such as [MetaMask's](https://faucet.metamask.io/) or [DeFi Karen's](https://faucet.ropsten.be/).
+If you need Ropsten ETH to transfer, you can get some from faucets such as [MetaMask's](https://faucet.metamask.io/) or [DeFi Karen's](https://faucet.ropsten.be/).
 For this tutorial, you should have (at least) 2 Ropsten ETH already on your account.
 
 ![metamask-two-ropsten-eth](../../_img/metamask_two_ropsten_eth.png)
@@ -40,6 +40,6 @@ After the transaction is complete (several minutes later) it will appear as "Com
 
 ![bridge-send-one-eth-to-aurora-completed](../../_img/bridge_send_one_eth_to_aurora_completed.png)
 
-You can now see your balance in MetaMask by switching to the Aurora testnet.
+You can now see your balance in MetaMask by switching to the Aurora Testnet.
 
 ![metamask-aurora-testnet-with-one-eth](../../_img/metamask_aurora_testnet_with_one_eth.png)

--- a/content/learn/connect/metamask.md
+++ b/content/learn/connect/metamask.md
@@ -13,8 +13,8 @@ If you need help getting set up with MetaMask in the first place, please see [th
 
 ## Connecting to the Bridge front-end
 
-Aurora is still a work in progress, so our bridge is currently only working with the Ropsten testnet (and Ethereum test network).
-For the remainder of the tutorial we will focus on adding the Aurora testnet to MetaMask.
+Aurora is still a work in progress, so our bridge is currently only working with the Ropsten Testnet (an Ethereum test network).
+For the remainder of the tutorial we will focus on adding the Aurora Testnet to MetaMask.
 
 Before we begin, ensure that you have the Ropsten network selected in MetaMask.
 In the MetaMask UI click the network selection drop-down in the top right, then click `Ropsten test network`.


### PR DESCRIPTION
This partially addresses #20 by adding linting for capitalization of proper nouns and a spell check. It is not complete because some things will still pass, but are not allowed according to the style guide (e.g. "Test Net" (with a space), "ERC20" (without the dash)). However, I didn't find simple pre-built tools to catch these cases. We may have to write something custom or extend an existing tool to handle those parts of the style guide.

I think it would also be good if the "style guide" was actually just a config file of some linter tool which enforced it. This way there would only be a single source of truth, whereas right now someone needs to update the linters when the style guide in basecamp changes.

I may work on something more complete in the future, but I think this PR is a good first step anyway (it caught some mistakes which are also fixed as part of this PR).