### PR TITLE
Remove all mentions of the Betanet

### DIFF
--- a/content/develop/changelog.md
+++ b/content/develop/changelog.md
@@ -61,40 +61,40 @@ title: "Aurora: Changelog"
 
 ## 2021-07-30
 
-### Testnet & Betanet only
+### Testnet
 
 - **Aurora Engine**: Deployed release [1.5.0](https://github.com/aurora-is-near/aurora-engine/releases/tag/1.5.0)
-  to Testnet and Betanet.
+  to Testnet.
 
 ## 2021-07-08
 
-### Testnet & Betanet only
+### Testnet
 
 - **Aurora Engine**: Deployed release [1.4.3](https://github.com/aurora-is-near/aurora-engine/releases/tag/1.4.3)
-  to Testnet and Betanet.
+  to Testnet.
 
 ## 2021-06-25
 
 ### All networks
 
 - **Aurora Engine**: Deployed release [1.4.2](https://github.com/aurora-is-near/aurora-engine/releases/tag/1.4.2)
-  to Mainnet, Testnet, and Betanet.
+  to Mainnet and Testnet.
 
 ## 2021-06-23
 
-### Testnet & Betanet only
+### Testnet
 
 - **Aurora Engine**: Deployed release [1.4.1](https://github.com/aurora-is-near/aurora-engine/releases/tag/1.4.1)
-  to Testnet and Betanet.
+  to Testnet.
 
 ## 2021-06-18
 
 - [The weekly update](https://aurora.dev/blog/2021-06-18-update)
 
-### Testnet & Betanet only
+### Testnet
 
 - **Aurora Engine**: Deployed release [1.4.0](https://github.com/aurora-is-near/aurora-engine/releases/tag/1.4.0)
-  to Testnet and Betanet.
+  to Testnet.
 
 ## 2021-06-17
 
@@ -105,19 +105,19 @@ title: "Aurora: Changelog"
   `eth_getTransactionReceipt` RPC methods.
   ([df29187](https://github.com/aurora-is-near/aurora-relayer/commit/df291873b859f1412306a60a7bfb69506f4d3336))
 
-### Testnet & Betanet only
+### Testnet
 
 - **Aurora Engine**: Deployed release [1.3.0](https://github.com/aurora-is-near/aurora-engine/releases/tag/1.3.0)
-  to Testnet and Betanet.
+  to Testnet.
 
 ## 2021-06-11
 
 - [The weekly update](https://aurora.dev/blog/2021-06-11-update)
 
-### Testnet & Betanet only
+### Testnet
 
 - **Aurora Engine**: Deployed release [1.2.0](https://github.com/aurora-is-near/aurora-engine/releases/tag/1.2.0)
-  to Testnet and Betanet.
+  to Testnet.
 
 ## 2021-06-09
 
@@ -159,7 +159,7 @@ title: "Aurora: Changelog"
 
 ## 2021-05-29
 
-### Testnet only
+### Testnet
 
 - **Aurora Engine**: Deployed release [1.1.0](https://github.com/aurora-is-near/aurora-engine/releases/tag/1.1.0)
   to Testnet.
@@ -211,4 +211,4 @@ title: "Aurora: Changelog"
 ### All networks
 
 - **Aurora Engine**: Deployed release [1.0.0](https://github.com/aurora-is-near/aurora-engine/releases/tag/1.0.0)
-  to Mainnet, Testnet, and Betanet.
+  to Mainnet and Testnet.

--- a/content/develop/networks.md
+++ b/content/develop/networks.md
@@ -13,7 +13,6 @@ Network  | Engine ID                  | Chain ID                | Endpoint URL
 -------- | -------------------------- | ----------------------- | ------------
 [Mainnet](#mainnet) | [`aurora`][aurora@Mainnet] | 1313161554 (0x4e454152) | <https://mainnet.aurora.dev>
 [Testnet](#testnet) | [`aurora`][aurora@Testnet] | 1313161555 (0x4e454153) | <https://testnet.aurora.dev>
-[Betanet](#betanet) | [`aurora`][aurora@Betanet] | 1313161556 (0x4e454154) | <https://betanet.aurora.dev>
 Localnet | `aurora.test.near`         | 1313161556 (0x4e454154) | <http://localhost:8545>
 
 Find the status page and public incident log at
@@ -30,14 +29,8 @@ The Mainnet Web3 endpoint is at: `https://mainnet.aurora.dev` (port 443)
 
 The Testnet Web3 endpoint is at: `https://testnet.aurora.dev` (port 443)
 
-### Betanet
-
-The Betanet Web3 endpoint is at: `https://betanet.aurora.dev` (port 443)
-
 [aurora@Mainnet]: https://explorer.near.org/accounts/aurora
 [aurora@Testnet]: https://explorer.testnet.near.org/accounts/aurora
-[aurora@Betanet]: https://explorer.betanet.near.org/accounts/aurora
 
 [mainnet.aurora.dev]: https://mainnet.aurora.dev
 [testnet.aurora.dev]: https://testnet.aurora.dev
-[betanet.aurora.dev]: https://betanet.aurora.dev


### PR DESCRIPTION
## What

We've talked about decommissioning Betanet several times. I believe getting rid of all the mentions is a good first step.
I have also removed all the Betanet mentions from the changelog, as I don't believe it was used externally to a meaningful extent.