### PR TITLE
Fix Discord link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,7 +117,7 @@ extra:
       link: https://gov.near.org/c/dev/aurora/46
     - name: Aurora on Discord
       icon: fontawesome/brands/discord
-      link: https://discord.gg/5G96uyKyCa
+      link: https://discord.aurora.dev/
     - name: Aurora on Telegram
       icon: fontawesome/brands/telegram
       link: https://t.me/auroraisnear

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,7 +117,7 @@ extra:
       link: https://gov.near.org/c/dev/aurora/46
     - name: Aurora on Discord
       icon: fontawesome/brands/discord
-      link: https://discord.gg/jNjHYUF8vw
+      link: https://discord.gg/5G96uyKyCa
     - name: Aurora on Telegram
       icon: fontawesome/brands/telegram
       link: https://t.me/auroraisnear


### PR DESCRIPTION
So it goes to Aurora's server (former link points to NEAR)