### PR TITLE
Update RPC compatibility list on JSON-RPC page

### DIFF
--- a/docs/compat/rpc.md
+++ b/docs/compat/rpc.md
@@ -19,7 +19,7 @@ Method | Status | Notes
 [net_version] | ✅ |
 [eth_accounts] | ✅ |
 [eth_blockNumber] | ✅ |
-[eth_call] | 🚧 |
+[eth_call] | ✅ |
 [eth_chainId] | ✅ |
 [eth_coinbase] | ✅ |
 [eth_compileLLL] | ❌ | Unsupported
@@ -53,14 +53,14 @@ Method | Status | Notes
 [eth_mining] | ✅ |
 [eth_newBlockFilter] | 🚧 |
 [eth_newFilter] | 🚧 |
-[eth_newPendingTransactionFilter] | 🚧 |
+[eth_newPendingTransactionFilter] | ✅ |
 [eth_pendingTransactions] | ✅ | [Undocumented](https://github.com/ethereum/go-ethereum/issues/1648#issuecomment-130591933)
 [eth_protocolVersion] | ✅ |
-[eth_sendRawTransaction] | 🚧 |
-[eth_sendTransaction] | 🚧 |
-[eth_sign] | 🚧 |
-[eth_signTransaction] | 🚧 |
-[eth_signTypedData] | 🚧 | EIP-712
+[eth_sendRawTransaction] | ✅ |
+[eth_sendTransaction] | ❌ | Unsupported
+[eth_sign] | ❌ | Unsupported
+[eth_signTransaction] | ❌ | Unsupported
+[eth_signTypedData] | ❌ | Unsupported
 [eth_submitHashrate] | ❌ | Unsupported
 [eth_submitWork] | ❌ | Unsupported
 [eth_syncing] | ✅ |
@@ -79,6 +79,10 @@ Method | Status | Notes
 [shh_post] | ❌ | Discontinued
 [shh_uninstallFilter] | ❌ | Discontinued
 [shh_version] | ❌ | Discontinued
+[txpool_content] | ✅ | Geth extension
+[txpool_inspect] | ✅ | Geth extension
+[txpool_status] | ✅ | Geth extension
+[parity_pendingTransactions] | ✅ | Parity extension
 
 **Legend**: ❌ = not supported. 🚧 = work in progress. ✅ = supported.
 
@@ -196,5 +200,9 @@ The Aurora Relayer source code repository is at:
 [shh_post]: https://eth.wiki/json-rpc/API#shh_post
 [shh_uninstallFilter]: https://eth.wiki/json-rpc/API#shh_uninstallFilter
 [shh_version]: https://eth.wiki/json-rpc/API#shh_version
+[txpool_content]: https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content
+[txpool_inspect]: https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_inspect
+[txpool_status]: https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_status
+[parity_pendingTransactions]: https://openethereum.github.io/JSONRPC-parity-module#parity_pendingtransactions
 
 [EIP-1186]: https://eips.ethereum.org/EIPS/eip-1186


### PR DESCRIPTION

## This PR is ceated to fix Issue #59 

The issue details are as follows 

Aurora-relayer compatibility with the Web3 JSON-RPC protocol is listed on project's Github page ("https://github.com/aurora-is-near/aurora-relayer") as well as "https://docs.aurora.dev/compat/rpc" page. However, there are differences between those pages as stated below. 

Differences between Github and docs.aurora.dev
 1) eth_call method is in supported state on github, but in-progress state on docs.aurora.dev. Needs to be updated as supported on docs.aurora.dev.
 2) eth_newPendingTransactionFilter method is in supported state on github, but in-progress state on docs.aurora.dev. Needs to be updated as supported on docs.aurora.dev.
 3) eth_sendRawTransaction method is in supported state on github, but in-progress state on docs.aurora.dev. Needs to be updated as supported on docs.aurora.dev.
 4) eth_sendTransaction method is in unsupported state on github, but in-progress state on docs.aurora.dev. Needs to be updated as unsupported on docs.aurora.dev.
 5) eth_sign method is in unsupported state on github, but in-progress state on docs.aurora.dev. Needs to be updated as unsupported on docs.aurora.dev.
 6) eth_signTransaction method is in unsupported state on github, but in-progress state on docs.aurora.dev. Needs to be updated as unsupported on docs.aurora.dev.
 7) eth_signTypedData method is in unsupported state on github, but in-progress state on docs.aurora.dev. Needs to be updated as unsupported on docs.aurora.dev.
 8) The following Geth and Parity extensions were marked as supported on github. These methods don't exist on docs.aurora.dev.
 This PR adds them as supported.
  * txpool_content
  * txpool_inspect
  * txpool_status
  * parity_pendingTransactions