### PR TITLE
Add Relayer 2.0 documentation

### DIFF
--- a/docs/evm/rpc.md
+++ b/docs/evm/rpc.md
@@ -4,7 +4,7 @@ title: "JSON-RPC"
 
 # Compatibility with the Web3 JSON-RPC Protocol
 
-The Aurora Relayer implements the Web3 JSON-RPC protocol.
+The [Aurora Relayer](https://github.com/aurora-is-near/relayer2-public) implements the Web3 JSON-RPC protocol.
 
 ## Methods
 
@@ -134,10 +134,9 @@ Method | Status | Notes
 ## Source Code
 
 The Aurora Relayer source code repository is at:
-[github.com/aurora-is-near/aurora-relayer](https://github.com/aurora-is-near/aurora-relayer).
+[github.com/aurora-is-near/relayer2-public](https://github.com/aurora-is-near/relayer2-public).
 
-> ⚠ WARNING: aurora-relayer repository in its current state will be gradually deprecated.
-> Deprecation will happen in 2 steps:
+> NOTE: Old [aurora-relayer](https://github.com/aurora-is-near/aurora-relayer) repository has been deprecated in 2 steps:
 >
 > 1. Replacing current “Indexer” with a different implementation written in go-lang/rust.
 > 2. Replacing “JSON-RPC Endpoint” with an implementation in go-lang.

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -41,7 +41,7 @@ It's often possible to optimise the contract to overcome the issue (reducing tra
 We're working hard on making the issue non-existent, but it's important to know it's present at the moment.
 
 ### Running your own Aurora Node
-If you feel like you need to run an Aurora Node yourself, please use [this setup](https://github.com/aurora-is-near/partner-relayer-deploy).
+If you feel like you need to run an Aurora Node yourself, please use [this setup](https://github.com/aurora-is-near/standalone-rpc/).
 The hardware requirements for the node are the same as for [NEAR RPC Node](https://docs.near.org/docs/develop/node/rpc/hardware-rpc#recommended-hardware-specifications) though we recommend having 20-30% more storage.
 
 ### Adding assets to the bridge


### PR DESCRIPTION
The new Relayer 2.0 release has happened this week:
[https://github.com/aurora-is-near/relayer2-public](https://github.com/aurora-is-near/relayer2-public
).

The [old one](https://github.com/aurora-is-near/aurora-relayer) is deprecated now.
Also the RPC Node setup was update due to this. The new one lives here now:
[https://github.com/aurora-is-near/standalone-rpc/](https://github.com/aurora-is-near/standalone-rpc/).

