### PR TITLE
Add Envio to indexers section

### DIFF
--- a/docs/dev-tools/indexers/envio.md
+++ b/docs/dev-tools/indexers/envio.md
@@ -45,16 +45,15 @@ chains:
 
 ### Get started
 
-* [Quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=aurora&utm_medium=partner-docs) - build your first Aurora indexer in minutes
+* [Quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=aurora&utm_medium=partner-docs) - auto-generate an indexer from any verified Aurora contract in minutes
 * [Documentation](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) - learn the full HyperIndex framework
-* [Contract Import](https://docs.envio.dev/docs/HyperIndex/contract-import?utm_source=aurora&utm_medium=partner-docs) - auto-generate an indexer from any verified Aurora contract
 * [Configuration guide](https://docs.envio.dev/docs/HyperIndex/configuration-file?utm_source=aurora&utm_medium=partner-docs) - set up your config, schema, and event handlers
 
 ## HyperSync
 
 [HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) is Envio's real-time indexed data layer, purpose-built to make retrieving large amounts of Aurora data dramatically faster than traditional RPC. Point your client at the Aurora endpoint and stream logs, transactions, blocks, and traces at high speed.
 
-The HyperSync endpoint for Aurora is `https://aurora.hypersync.xyz` and works with the HyperSync clients for Rust, Python, and Node.js.
+The HyperSync endpoint for Aurora is `https://aurora.hypersync.xyz` and works with the HyperSync clients for Python, Rust, Node.js, and Go.
 
 ### Get started
 

--- a/docs/dev-tools/indexers/envio.md
+++ b/docs/dev-tools/indexers/envio.md
@@ -1,0 +1,84 @@
+---
+title: Envio
+---
+[Envio](https://envio.dev/?utm_source=aurora&utm_medium=partner-docs) is a modular, hyper-performant data indexing solution for Aurora, giving developers real-time and historical access to on-chain data with minimal setup.
+
+Envio offers three solutions for indexing and accessing large amounts of Aurora data.
+
+1. [HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) - a customizable indexing framework that turns smart contract events into a queryable GraphQL API
+2. [HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) - a real-time indexed data layer for ultra-fast historical sync
+3. [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) - an extremely fast read-only RPC
+
+HyperSync accelerates the synchronisation of historical data on Aurora, so that what usually takes hours to sync millions of events can complete in under a minute, up to 2000x faster than traditional RPC methods.
+
+**Use Envio when you want**
+
+* Real-time and historical Aurora data through a single GraphQL API
+* Blazing-fast backfills powered by HyperSync
+* Multi-chain data aggregation across EVM and non-EVM networks
+* A flexible, developer-friendly indexer backed by a reliable, cost-effective hosted service
+
+> [**Start indexing Aurora with Envio**](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=aurora&utm_medium=partner-docs)
+
+## Network details
+
+Envio supports Aurora across HyperSync and HyperRPC.
+
+| **Field**                  | **Value**                                                                    |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| **Aurora Chain ID**        | 1313161554                                                                   |
+| **HyperSync URL Endpoint** | `https://aurora.hypersync.xyz` or `https://1313161554.hypersync.xyz`         |
+| **HyperRPC URL Endpoint**  | `https://aurora.rpc.hypersync.xyz` or `https://1313161554.rpc.hypersync.xyz` |
+
+## HyperIndex
+
+[HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) is Envio's full-featured indexing framework. It offers automatic code generation, flexible language support (TypeScript, JavaScript, and ReScript), and multi-chain data aggregation, letting you go from smart contract events to a queryable GraphQL API in minutes.
+
+Add Aurora to your indexer by defining a chain configuration.
+
+```yaml
+name: IndexerName # Specify indexer name
+description: Indexer Description # Include indexer description
+chains:
+  - id: 1313161554 # Aurora
+    start_block: START_BLOCK_NUMBER # Specify the starting block
+    contracts:
+      - name: ContractName
+        address:
+          - "0xYourContractAddress1"
+          - "0xYourContractAddress2"
+        events:
+          - event: Event # Specify event
+          - event: Event
+```
+
+For more on how to set up your config, define a schema, and write event handlers, see the [configuration guide](https://docs.envio.dev/docs/HyperIndex/configuration-file?utm_source=aurora&utm_medium=partner-docs).
+
+### Get started
+
+* [Quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=aurora&utm_medium=partner-docs) - build your first Aurora indexer in minutes
+* [Documentation](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) - learn the full HyperIndex framework
+* [Contract Import](https://docs.envio.dev/docs/HyperIndex/contract-import?utm_source=aurora&utm_medium=partner-docs) - auto-generate an indexer from any verified Aurora contract
+
+## HyperSync
+
+[HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) is Envio's real-time indexed data layer, purpose-built to make retrieving large amounts of Aurora data dramatically faster than traditional RPC. Point your client at the Aurora endpoint and stream logs, transactions, blocks, and traces at high speed.
+
+* HyperSync endpoint for Aurora is `https://aurora.hypersync.xyz`
+* Works with the HyperSync clients for Rust, Python, and Node.js
+
+See the [HyperSync documentation](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) to get started.
+
+## HyperRPC
+
+[HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) is an extremely fast, read-only RPC for data-heavy workloads on Aurora. It is a drop-in endpoint for read requests where you need high throughput over historical data.
+
+* HyperRPC endpoint for Aurora is `https://aurora.rpc.hypersync.xyz`
+
+## About Envio
+
+Envio is a modular, hyper-performant data indexing solution for Web3, giving developers real-time and historical access to on-chain data across EVM and non-EVM networks. Teams use Envio to power dashboards, analytics, wallets, and dApps with fast, reliable, cost-effective data infrastructure.
+
+Need help with your Aurora indexer? Reach out on [Discord](https://discord.gg/envio), where the team is always happy to help.
+
+[Website](https://envio.dev/?utm_source=aurora&utm_medium=partner-docs) | [Docs](https://docs.envio.dev/?utm_source=aurora&utm_medium=partner-docs) | [Discord](https://discord.gg/envio) | [X](https://twitter.com/envio_indexer) | [GitHub](https://github.com/enviodev)

--- a/docs/dev-tools/indexers/envio.md
+++ b/docs/dev-tools/indexers/envio.md
@@ -1,13 +1,14 @@
 ---
 title: Envio
 ---
-[Envio](https://envio.dev/?utm_source=aurora&utm_medium=partner-docs) is a modular, hyper-performant data indexing solution for Aurora, giving developers real-time and historical access to on-chain data with minimal setup.
+[Envio](https://envio.dev/?utm_source=aurora&utm_medium=partner-docs) is the data layer for blockchain apps. It gives Aurora developers the fastest, most flexible way to get real-time and historical onchain data, with minimal setup.
 
-Envio offers three solutions for indexing and accessing large amounts of Aurora data.
+Envio offers a complete toolkit for indexing, accessing, and deploying on Aurora data.
 
-1. [HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) - a customizable indexing framework that turns smart contract events into a queryable GraphQL API
-2. [HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) - a real-time indexed data layer for ultra-fast historical sync
-3. [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) - an extremely fast read-only RPC
+1. [HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) - a full-featured indexing framework that turns smart contract events into a queryable GraphQL API
+2. [HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) - a real-time indexed data layer for ultrafast historical sync
+3. [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) - an extremely fast, read-only RPC
+4. [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=aurora&utm_medium=partner-docs) - a fully managed platform to deploy and scale your indexers without the infrastructure headaches
 
 HyperSync accelerates the synchronisation of historical data on Aurora, so that what usually takes hours to sync millions of events can complete in under a minute, up to 2000x faster than traditional RPC methods.
 
@@ -16,7 +17,7 @@ HyperSync accelerates the synchronisation of historical data on Aurora, so that 
 * Real-time and historical Aurora data through a single GraphQL API
 * Blazing-fast backfills powered by HyperSync
 * Multi-chain data aggregation across EVM and non-EVM networks
-* A flexible, developer-friendly indexer backed by a reliable, cost-effective hosted service
+* A flexible, developer-friendly indexer with managed hosting on Envio Cloud
 
 > [**Start indexing Aurora with Envio**](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=aurora&utm_medium=partner-docs)
 
@@ -75,9 +76,16 @@ See the [HyperSync documentation](https://docs.envio.dev/docs/HyperSync/overview
 
 * HyperRPC endpoint for Aurora is `https://aurora.rpc.hypersync.xyz`
 
+## Deploy with Envio Cloud
+
+[Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=aurora&utm_medium=partner-docs) is a fully managed platform for running your Aurora indexers in production, so you can deploy and scale without the infrastructure headaches. It gives you a git-based deployment workflow similar to modern platforms like Vercel, plus hosted GraphQL APIs, built-in monitoring and alerting, zero-downtime deploys, and continuous backups.
+
+* [Deploying your indexer](https://docs.envio.dev/docs/HyperIndex/hosted-service-deployment?utm_source=aurora&utm_medium=partner-docs) - ship your Aurora indexer with a git-based workflow
+* [Envio Cloud features](https://docs.envio.dev/docs/HyperIndex/hosted-service-features?utm_source=aurora&utm_medium=partner-docs) - production-ready hosting, monitoring, and scaling
+
 ## About Envio
 
-Envio is a modular, hyper-performant data indexing solution for Web3, giving developers real-time and historical access to on-chain data across EVM and non-EVM networks. Teams use Envio to power dashboards, analytics, wallets, and dApps with fast, reliable, cost-effective data infrastructure.
+Envio is the data layer for blockchain apps, giving developers the fastest, most flexible way to access real-time and historical onchain data across EVM and non-EVM networks. Teams use Envio to power dashboards, analytics, wallets, and dApps with fast, reliable, cost-effective data infrastructure.
 
 Need help with your Aurora indexer? Reach out on [Discord](https://discord.gg/envio), where the team is always happy to help.
 

--- a/docs/dev-tools/indexers/envio.md
+++ b/docs/dev-tools/indexers/envio.md
@@ -1,18 +1,18 @@
 ---
 title: Envio
 ---
-[Envio](https://envio.dev/?utm_source=aurora&utm_medium=partner-docs) is the data layer for blockchain apps. It gives Aurora developers the fastest, most flexible way to get real-time and historical onchain data, with minimal setup.
+[Envio](https://envio.dev/?utm_source=aurora&utm_medium=partner-docs) is the data layer for blockchain apps, giving developers the fastest, most flexible way to get real-time and historical onchain data across [many EVM and non-EVM networks](https://docs.envio.dev/docs/HyperSync/hypersync-supported-networks?utm_source=aurora&utm_medium=partner-docs), including [Aurora](https://docs.envio.dev/docs/HyperIndex/aurora?utm_source=aurora&utm_medium=partner-docs).
 
-Envio offers a complete toolkit for indexing, accessing, and deploying on Aurora data.
+Envio provides a complete toolkit to index, access, and deploy on Aurora data.
 
 1. [HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) - a full-featured indexing framework that turns smart contract events into a queryable GraphQL API
 2. [HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) - a real-time indexed data layer for ultrafast historical sync
 3. [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) - an extremely fast, read-only RPC
-4. [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=aurora&utm_medium=partner-docs) - a fully managed platform to deploy and scale your indexers without the infrastructure headaches
+4. [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=aurora&utm_medium=partner-docs) - a fully managed platform to deploy and scale your indexers
 
 HyperSync accelerates the synchronisation of historical data on Aurora, so that what usually takes hours to sync millions of events can complete in under a minute, up to 2000x faster than traditional RPC methods.
 
-**Use Envio when you want**
+**Use Envio if you need:**
 
 * Real-time and historical Aurora data through a single GraphQL API
 * Blazing-fast backfills powered by HyperSync
@@ -21,21 +21,11 @@ HyperSync accelerates the synchronisation of historical data on Aurora, so that 
 
 > [**Start indexing Aurora with Envio**](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=aurora&utm_medium=partner-docs)
 
-## Network details
-
-Envio supports Aurora across HyperSync and HyperRPC.
-
-| **Field**                  | **Value**                                                                    |
-| -------------------------- | ---------------------------------------------------------------------------- |
-| **Aurora Chain ID**        | 1313161554                                                                   |
-| **HyperSync URL Endpoint** | `https://aurora.hypersync.xyz` or `https://1313161554.hypersync.xyz`         |
-| **HyperRPC URL Endpoint**  | `https://aurora.rpc.hypersync.xyz` or `https://1313161554.rpc.hypersync.xyz` |
-
 ## HyperIndex
 
 [HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) is Envio's full-featured indexing framework. It offers automatic code generation, flexible language support (TypeScript, JavaScript, and ReScript), and multi-chain data aggregation, letting you go from smart contract events to a queryable GraphQL API in minutes.
 
-Add Aurora to your indexer by defining a chain configuration.
+Add Aurora (chain ID 1313161554) to your indexer by defining a chain configuration.
 
 ```yaml
 name: IndexerName # Specify indexer name
@@ -53,32 +43,38 @@ chains:
           - event: Event
 ```
 
-For more on how to set up your config, define a schema, and write event handlers, see the [configuration guide](https://docs.envio.dev/docs/HyperIndex/configuration-file?utm_source=aurora&utm_medium=partner-docs).
-
 ### Get started
 
 * [Quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=aurora&utm_medium=partner-docs) - build your first Aurora indexer in minutes
 * [Documentation](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) - learn the full HyperIndex framework
 * [Contract Import](https://docs.envio.dev/docs/HyperIndex/contract-import?utm_source=aurora&utm_medium=partner-docs) - auto-generate an indexer from any verified Aurora contract
+* [Configuration guide](https://docs.envio.dev/docs/HyperIndex/configuration-file?utm_source=aurora&utm_medium=partner-docs) - set up your config, schema, and event handlers
 
 ## HyperSync
 
 [HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) is Envio's real-time indexed data layer, purpose-built to make retrieving large amounts of Aurora data dramatically faster than traditional RPC. Point your client at the Aurora endpoint and stream logs, transactions, blocks, and traces at high speed.
 
-* HyperSync endpoint for Aurora is `https://aurora.hypersync.xyz`
-* Works with the HyperSync clients for Rust, Python, and Node.js
+The HyperSync endpoint for Aurora is `https://aurora.hypersync.xyz` and works with the HyperSync clients for Rust, Python, and Node.js.
 
-See the [HyperSync documentation](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) to get started.
+### Get started
+
+* [HyperSync documentation](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) - learn how to query Aurora data with HyperSync
 
 ## HyperRPC
 
 [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) is an extremely fast, read-only RPC for data-heavy workloads on Aurora. It is a drop-in endpoint for read requests where you need high throughput over historical data.
 
-* HyperRPC endpoint for Aurora is `https://aurora.rpc.hypersync.xyz`
+The HyperRPC endpoint for Aurora is `https://aurora.rpc.hypersync.xyz`.
 
-## Deploy with Envio Cloud
+### Get started
+
+* [HyperRPC documentation](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) - learn how to use HyperRPC on Aurora
+
+## Envio Cloud
 
 [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=aurora&utm_medium=partner-docs) is a fully managed platform for running your Aurora indexers in production, so you can deploy and scale without the infrastructure headaches. It gives you a git-based deployment workflow similar to modern platforms like Vercel, plus hosted GraphQL APIs, built-in monitoring and alerting, zero-downtime deploys, and continuous backups.
+
+### Get started
 
 * [Deploying your indexer](https://docs.envio.dev/docs/HyperIndex/hosted-service-deployment?utm_source=aurora&utm_medium=partner-docs) - ship your Aurora indexer with a git-based workflow
 * [Envio Cloud features](https://docs.envio.dev/docs/HyperIndex/hosted-service-features?utm_source=aurora&utm_medium=partner-docs) - production-ready hosting, monitoring, and scaling
@@ -86,7 +82,5 @@ See the [HyperSync documentation](https://docs.envio.dev/docs/HyperSync/overview
 ## About Envio
 
 Envio is the data layer for blockchain apps, giving developers the fastest, most flexible way to access real-time and historical onchain data across EVM and non-EVM networks. Teams use Envio to power dashboards, analytics, wallets, and dApps with fast, reliable, cost-effective data infrastructure.
-
-Need help with your Aurora indexer? Reach out on [Discord](https://discord.gg/envio), where the team is always happy to help.
 
 [Website](https://envio.dev/?utm_source=aurora&utm_medium=partner-docs) | [Docs](https://docs.envio.dev/?utm_source=aurora&utm_medium=partner-docs) | [Discord](https://discord.gg/envio) | [X](https://twitter.com/envio_indexer) | [GitHub](https://github.com/enviodev)

--- a/docs/dev-tools/indexers/envio.md
+++ b/docs/dev-tools/indexers/envio.md
@@ -1,31 +1,41 @@
 ---
 title: Envio
 ---
-[Envio](https://envio.dev/?utm_source=aurora&utm_medium=partner-docs) is the data layer for blockchain apps, giving developers the fastest, most flexible way to get real-time and historical onchain data across [many EVM and non-EVM networks](https://docs.envio.dev/docs/HyperSync/hypersync-supported-networks?utm_source=aurora&utm_medium=partner-docs), including [Aurora](https://docs.envio.dev/docs/HyperIndex/aurora?utm_source=aurora&utm_medium=partner-docs).
+The fastest, most flexible way to get real-time and historical onchain data on Aurora.
 
-Envio provides a complete toolkit to index, access, and deploy on Aurora data.
+[Envio](https://envio.dev/?utm_source=aurora&utm_medium=partner-docs) is the data layer for blockchain apps. It gives developers a complete toolkit to index, access, and deploy on Aurora data, from a single GraphQL API to raw high-speed data access. Aurora is [fully supported](https://docs.envio.dev/docs/HyperIndex/aurora?utm_source=aurora&utm_medium=partner-docs) across [HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs), [HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs), [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs), and [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=aurora&utm_medium=partner-docs).
 
-1. [HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) - a full-featured indexing framework that turns smart contract events into a queryable GraphQL API
-2. [HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) - a real-time indexed data layer for ultrafast historical sync
-3. [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) - an extremely fast, read-only RPC
-4. [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=aurora&utm_medium=partner-docs) - a fully managed platform to deploy and scale your indexers
+## Why Envio?
 
-HyperSync accelerates the synchronisation of historical data on Aurora, so that what usually takes hours to sync millions of events can complete in under a minute, up to 2000x faster than traditional RPC methods.
+Compared to other indexing options, the main reasons developers choose Envio are:
 
-**Use Envio if you need:**
+* ⚡ **Blazing-fast sync** powered by HyperSync, so historical backfills on Aurora that once took hours can complete in under a minute, up to 2000x faster than traditional RPC.
+* 🧩 **A complete toolkit** in one place, with HyperIndex for full indexing, HyperSync for raw high-speed data, HyperRPC as a drop-in read-only RPC, and Envio Cloud for managed hosting.
+* 🧑‍💻 **Developer-friendly** by design, with automatic code generation, a queryable GraphQL API, and flexible language support (TypeScript, JavaScript, and ReScript).
+* 🌐 **Multichain** from day one, aggregating Aurora data alongside other EVM and non-EVM networks.
+* ☁️ **Managed or self-hosted**, so you can deploy and scale on Envio Cloud without the infrastructure headaches, or run your own setup.
 
-* Real-time and historical Aurora data through a single GraphQL API
-* Blazing-fast backfills powered by HyperSync
-* Multi-chain data aggregation across EVM and non-EVM networks
-* A flexible, developer-friendly indexer with managed hosting on Envio Cloud
+### Features
 
-> [**Start indexing Aurora with Envio**](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=aurora&utm_medium=partner-docs)
+* ✅ Real-time indexing with historical backfills at 30,000+ events per second
+* ✅ Auto-generate an indexer from any verified Aurora contract with `pnpx envio init`
+* ✅ A GraphQL API over your indexed Aurora data
+* ✅ Reorg support that gracefully handles chain reorganisations
+* ✅ Multichain data aggregation across EVM and non-EVM networks
+* ✅ Direct data access via HyperSync (`https://aurora.hypersync.xyz`) and HyperRPC (`https://aurora.rpc.hypersync.xyz`)
+* ✅ Managed hosting on Envio Cloud, or self-host your own deployment
 
-## HyperIndex
+## Getting Started
 
-[HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) is Envio's full-featured indexing framework. It offers automatic code generation, flexible language support (TypeScript, JavaScript, and ReScript), and multi-chain data aggregation, letting you go from smart contract events to a queryable GraphQL API in minutes.
+1️⃣ Initialise your indexer and import your Aurora contract.
 
-Add Aurora (chain ID 1313161554) to your indexer by defining a chain configuration.
+```shell
+pnpx envio init
+```
+
+Choose **Contract Import** and provide your verified Aurora contract address to auto-generate a config, schema, and event handlers. See the [Quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=aurora&utm_medium=partner-docs) for the full walkthrough.
+
+2️⃣ Configure Aurora in your `config.yaml` using chain ID `1313161554`.
 
 ```yaml
 name: IndexerName # Specify indexer name
@@ -43,43 +53,16 @@ chains:
           - event: Event
 ```
 
-### Get started
+See the [configuration guide](https://docs.envio.dev/docs/HyperIndex/configuration-file?utm_source=aurora&utm_medium=partner-docs) for the full set of options.
 
-* [Quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=aurora&utm_medium=partner-docs) - auto-generate an indexer from any verified Aurora contract in minutes
-* [Documentation](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=aurora&utm_medium=partner-docs) - learn the full HyperIndex framework
-* [Configuration guide](https://docs.envio.dev/docs/HyperIndex/configuration-file?utm_source=aurora&utm_medium=partner-docs) - set up your config, schema, and event handlers
+3️⃣ Run your indexer locally with Docker, or deploy it with a git-based workflow on [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service-deployment?utm_source=aurora&utm_medium=partner-docs).
 
-## HyperSync
+4️⃣ Query your indexed Aurora data through the GraphQL API.
 
-[HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) is Envio's real-time indexed data layer, purpose-built to make retrieving large amounts of Aurora data dramatically faster than traditional RPC. Point your client at the Aurora endpoint and stream logs, transactions, blocks, and traces at high speed.
+For raw, high-speed data without a full indexer, point a [HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) client at `https://aurora.hypersync.xyz`, or use [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) as a drop-in read-only RPC at `https://aurora.rpc.hypersync.xyz`.
 
-The HyperSync endpoint for Aurora is `https://aurora.hypersync.xyz` and works with the HyperSync clients for Python, Rust, Node.js, and Go.
+## Need help?
 
-### Get started
-
-* [HyperSync documentation](https://docs.envio.dev/docs/HyperSync/overview?utm_source=aurora&utm_medium=partner-docs) - learn how to query Aurora data with HyperSync
-
-## HyperRPC
-
-[HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) is an extremely fast, read-only RPC for data-heavy workloads on Aurora. It is a drop-in endpoint for read requests where you need high throughput over historical data.
-
-The HyperRPC endpoint for Aurora is `https://aurora.rpc.hypersync.xyz`.
-
-### Get started
-
-* [HyperRPC documentation](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=aurora&utm_medium=partner-docs) - learn how to use HyperRPC on Aurora
-
-## Envio Cloud
-
-[Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=aurora&utm_medium=partner-docs) is a fully managed platform for running your Aurora indexers in production, so you can deploy and scale without the infrastructure headaches. It gives you a git-based deployment workflow similar to modern platforms like Vercel, plus hosted GraphQL APIs, built-in monitoring and alerting, zero-downtime deploys, and continuous backups.
-
-### Get started
-
-* [Deploying your indexer](https://docs.envio.dev/docs/HyperIndex/hosted-service-deployment?utm_source=aurora&utm_medium=partner-docs) - ship your Aurora indexer with a git-based workflow
-* [Envio Cloud features](https://docs.envio.dev/docs/HyperIndex/hosted-service-features?utm_source=aurora&utm_medium=partner-docs) - production-ready hosting, monitoring, and scaling
-
-## About Envio
-
-Envio is the data layer for blockchain apps, giving developers the fastest, most flexible way to access real-time and historical onchain data across EVM and non-EVM networks. Teams use Envio to power dashboards, analytics, wallets, and dApps with fast, reliable, cost-effective data infrastructure.
+Reach out on [Discord](https://discord.gg/envio), where the team is always happy to help.
 
 [Website](https://envio.dev/?utm_source=aurora&utm_medium=partner-docs) | [Docs](https://docs.envio.dev/?utm_source=aurora&utm_medium=partner-docs) | [Discord](https://discord.gg/envio) | [X](https://twitter.com/envio_indexer) | [GitHub](https://github.com/enviodev)

--- a/sidebars.js
+++ b/sidebars.js
@@ -260,6 +260,7 @@ const sidebars = {
         collapsed: false,
         description: "React to the on-chain events emitted by smart contracts, store and analyze your data in a database by using indexers",
         items: [
+          'dev-tools/indexers/envio',
           'dev-tools/indexers/covalent',
           'dev-tools/indexers/flair',
           'dev-tools/indexers/the-graph',


### PR DESCRIPTION
This PR adds Envio to the Indexers section under Dev Tools.

**What's included**
- New page `docs/dev-tools/indexers/envio.md` covering HyperIndex, HyperSync, and HyperRPC, with Aurora network details (chain ID 1313161554 and the Aurora HyperSync/HyperRPC endpoints).
- Adds `dev-tools/indexers/envio` to the top of the Indexers list in `sidebars.js`.

Envio is a modular, hyper-performant data indexing solution that gives Aurora developers real-time and historical on-chain data through a single GraphQL API, with HyperSync backfills up to 2000x faster than traditional RPC.

Links: [envio.dev](https://envio.dev) · [docs.envio.dev](https://docs.envio.dev) · [Aurora support](https://docs.envio.dev/docs/HyperIndex/aurora)

Open to any adjustments to wording, ordering, or formatting to match your conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Envio’s HyperIndex, HyperSync, and HyperRPC indexing services.
  * Included Aurora network details, endpoint information, setup guidance, configuration examples, and resource links.
  * Added the Envio documentation page to the Indexers navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->