### PR TITLE
docs: add OpenChainBench live RPC latency benchmark link

### DIFF
--- a/docs/dev-reference/network-endpoints.md
+++ b/docs/dev-reference/network-endpoints.md
@@ -51,3 +51,5 @@ The Testnet Websocket endpoint is at: `wss://testnet.aurora.dev`
 [aurora@Mainnet]: https://explorer.near.org/accounts/aurora
 
 [aurora@Testnet]: https://explorer.testnet.near.org/accounts/aurora
+
+> Live latency benchmarks for these endpoints (p50/p90/p99, 3 regions, updated every 60 s): [OpenChainBench Aurora RPC](https://openchainbench.com/benchmarks/aurora-rpc)


### PR DESCRIPTION
Adds a reference to [OpenChainBench](https://openchainbench.com/benchmarks/aurora-rpc), which independently monitors Aurora RPC endpoint latency (p50/p90/p99, `eth_getBlockByNumber`, 3 probe regions, updated every 60 seconds). Useful for developers choosing between providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to live latency benchmarks for Aurora RPC endpoints.
  * Benchmark data includes p50, p90, and p99 performance metrics across three regions, refreshed every 60 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->