### PR TITLE
docs: fix dead Hardhat Runtime Environment links

### DIFF
--- a/docs/build-a-dapp/contracts/erc-20.md
+++ b/docs/build-a-dapp/contracts/erc-20.md
@@ -98,7 +98,7 @@ export TOKEN_ADDRESS='YOUR OUTPUT FROM DEPLOY (e.g. 0xD7f2A76F5DA173043E6c61a0A1
 We will use Hardhat tasks to take care of parsing the values provided for each parameter.
 It gets the values, performs the type validation and converts them into your desired type.
 
-In this example, we will go through a set of predefined Hardhat tasks that use the [Hardhat Runtime Environment](https://hardhat.org/advanced/hardhat-runtime-environment.html).
+In this example, we will go through a set of predefined Hardhat tasks that use the [Hardhat Runtime Environment](https://hardhat.org/hardhat-runner/docs/advanced/hardhat-runtime-environment).
 
 :::note
 The Hardhat Runtime Environment is an object containing all the functionality that Hardhat exposes when running a task, test or script. In reality, Hardhat is the HRE.

--- a/docs/dev-tools/basics/hardhat.md
+++ b/docs/dev-tools/basics/hardhat.md
@@ -46,7 +46,7 @@ $ export TOKEN_ADDRESS='YOUR OUTPUT FROM DEPLOY (e.g. 0xD7f2A76F5DA173043E6c61a0
 
 Hardhat tasks take care of parsing the values provided for each parameter. It gets the values, performs the type validation and converts them into your desired type.
 
-In this example, we will go through a set of pre-defined Hardhat tasks that uses the Hardhat Runtime Environment ([HRE](https://hardhat.org/advanced/hardhat-runtime-environment.html)). In order to complete the tutorial, you should use them in the same order:
+In this example, we will go through a set of pre-defined Hardhat tasks that uses the Hardhat Runtime Environment ([HRE](https://hardhat.org/hardhat-runner/docs/advanced/hardhat-runtime-environment)). In order to complete the tutorial, you should use them in the same order:
 
 ### ETH Balance[​](https://doc.aurora.dev/interact/hardhat/#eth-balance "Direct link to heading")
 


### PR DESCRIPTION
## Problem

Two tutorial pages link to `https://hardhat.org/advanced/hardhat-runtime-environment.html`, which returns 404 — Hardhat restructured its documentation and the flat `/advanced/*.html` paths are gone.

| File | Line |
|---|---|
| `docs/build-a-dapp/contracts/erc-20.md` | 101 |
| `docs/dev-tools/basics/hardhat.md` | 49 |

Both are core walkthroughs, and in both cases the link is the only explanation of what the Hardhat Runtime Environment is — so a reader who does not already know gets a dead end.

## Fix

Point both at the current page: `https://hardhat.org/hardhat-runner/docs/advanced/hardhat-runtime-environment`.

## Verification

Old URL confirmed 404 twice, replacement confirmed 200 twice. These were the only two occurrences of the broken path in the repo; the remaining `hardhat.org` links all resolve.

Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Hardhat Runtime Environment links to point to the current Hardhat documentation.
  - Refreshed references in the ERC-20 dApp guide and Hardhat Tasks documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->